### PR TITLE
fix: gh-pages.ymlで pnpm install --frozen-lockfile

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,7 +47,7 @@ jobs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Install Dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Build and Export
       env:


### PR DESCRIPTION
#18 を修正するものです。